### PR TITLE
changed tree-shaking format to reduce bundle sizing

### DIFF
--- a/src/components/Icon/FontAwesomeIcons.ts
+++ b/src/components/Icon/FontAwesomeIcons.ts
@@ -1,25 +1,23 @@
-export {
-  faPlus,
-  faUserShield,
-  faCalendar,
-  faCalendarPlus,
-  faCalendarMinus,
-  faCalendarAlt,
-  faColumns,
-  faChevronDown,
-  faEdit,
-  faCamera,
-  faFileAlt,
-  faMicroscope,
-  faChevronLeft,
-  faPills,
-  faUser,
-  faUserPlus,
-  faUserMinus,
-  faUsers,
-  faMinus,
-  faChevronRight,
-  faSave,
-  faCog,
-  faChevronUp,
-} from '@fortawesome/free-solid-svg-icons'
+export { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
+export { faUserShield } from '@fortawesome/free-solid-svg-icons/faUserShield'
+export { faCalendar } from '@fortawesome/free-solid-svg-icons/faCalendar'
+export { faCalendarPlus, } from '@fortawesome/free-solid-svg-icons/faCalendarPlus'
+export { faCalendarMinus } from '@fortawesome/free-solid-svg-icons/faCalendarMinus'
+export { faCalendarAlt } from '@fortawesome/free-solid-svg-icons/faCalendarAlt'
+export { faColumns } from '@fortawesome/free-solid-svg-icons/faColumns'
+export { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown'
+export { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit'
+export { faCamera } from '@fortawesome/free-solid-svg-icons/faCamera'
+export { faFileAlt } from '@fortawesome/free-solid-svg-icons/faFileAlt'
+export { faMicroscope } from '@fortawesome/free-solid-svg-icons/faMicroscope'
+export { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft'
+export { faPills } from '@fortawesome/free-solid-svg-icons/faPills'
+export { faUser } from '@fortawesome/free-solid-svg-icons/faUser'
+export { faUserPlus } from '@fortawesome/free-solid-svg-icons/faUserPlus'
+export { faUserMinus } from '@fortawesome/free-solid-svg-icons/faUserMinus'
+export { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
+export { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus'
+export { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight'
+export { faSave } from '@fortawesome/free-solid-svg-icons/faSave'
+export { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
+export { faChevronUp } from '@fortawesome/free-solid-svg-icons/faChevronUp'


### PR DESCRIPTION
Fixes #278
**Changes proposed in this pull request:**
- Changes the formatting of the import statements so that the bundler can run tree shaking
- Individually imports the different SVG's

Also should make an impact on https://github.com/HospitalRun/hospitalrun-frontend/issues/1808

*Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Provide tests for all code that you add/modify. If you add/modify any components update the storybook. Thanks! (you can delete this text)*
